### PR TITLE
updated bootstrap cdn links to newer version 4.5 

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
     <head>
         <title>Library Reissuer</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/css/bootstrap.min.css">
+        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
         <link rel="icon" type="image/ico" href="pics/icon.png"/>
         <link rel="stylesheet" href="./index.css">
     </head>


### PR DESCRIPTION
I have updated bootstrap cdn links to newer version 4.5 from very older version 3.4